### PR TITLE
[break:feat] make connection available in props

### DIFF
--- a/examples/connections.js
+++ b/examples/connections.js
@@ -21,9 +21,12 @@ const WrappedNode = createNode(collect => ({
   getNodeData: (props) => props.data,
 }))(Node);
 
-const nodes = NODES.map((nodeData, idx) => <WrappedNode onConnect={(a, b) => {
-  console.log('on', a, b);
-}} key={idx} data={nodeData} />);
+const nodes = NODES.map((nodeData, idx) => <WrappedNode
+  onConnect={(a, b) => { console.log('onConnect', a, b); }}
+  onActive={(data) => { console.log('onActive', data); }}
+  key={idx}
+  data={nodeData}
+/>);
 // @Provider(...)
 class App extends React.Component {
   render() {
@@ -59,12 +62,16 @@ class Wrapper extends Component {
       connections: after,
     });
   }
+  handleActiveNodeChange(data) {
+    console.log('onActiveNode change', data);
+  }
   render() {
     return (<div>
       <button onClick={this::this.handleClick}>change connections</button>
       <SimpleApp
         connections={this.state.connections}
         onConnectionsChange={this.handleConnectionsChange.bind(this)}
+        onActiveNodeChange={this.handleActiveNodeChange.bind(this)}
       />
     </div>);
   }

--- a/examples/connections.js
+++ b/examples/connections.js
@@ -1,5 +1,5 @@
 import { createContainer, createNode, createConnects } from 'rc-fringing';
-import React from 'react';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 
 import 'rc-fringing/assets/index.less';
@@ -21,7 +21,9 @@ const WrappedNode = createNode(collect => ({
   getNodeData: (props) => props.data,
 }))(Node);
 
-const nodes = NODES.map((nodeData, idx) => <WrappedNode key={idx} data={nodeData} />);
+const nodes = NODES.map((nodeData, idx) => <WrappedNode onConnect={(a, b) => {
+  console.log('on', a, b);
+}} key={idx} data={nodeData} />);
 // @Provider(...)
 class App extends React.Component {
   render() {
@@ -33,12 +35,42 @@ const SimpleApp = createContainer({
   width: 800,
   height: 600,
   onNodeChange: (id, data) => console.log('>> onNodeChange', id, data),
-  connects: [
-    { from: { id: 1, point: 'r' }, to: { id: 2, point: 'l'}},
-    { from: { id: 3, point: 'r' }, to: { id: 4, point: 'r'}},
-    { from: { id: 3, point: 'l' }, to: { id: 4, point: 'l'}},
-  ],
 })(App);
 
 
-ReactDOM.render(<SimpleApp />, document.getElementById('__react-content'));
+class Wrapper extends Component {
+  constructor(...arg) {
+    super(...arg);
+    this.state = {
+      connections: [{ from: { id: 1, point: 'r' }, to: { id: 2, point: 'l' } }],
+    }
+  }
+  handleClick() {
+    this.setState({
+      connections: [
+        { from: { id: 1, point: 'r' }, to: { id: 2, point: 'l'}},
+        { from: { id: 3, point: 'r' }, to: { id: 4, point: 'r'}},
+        { from: { id: 3, point: 'l' }, to: { id: 4, point: 'l'}},
+      ],
+    });
+  }
+  handleConnectionsChange(before, after) {
+    this.setState({
+      connections: after,
+    });
+  }
+  render() {
+    return (<div>
+      <button onClick={this::this.handleClick}>change connections</button>
+      <SimpleApp
+        connections={this.state.connections}
+        onConnectionsChange={this.handleConnectionsChange.bind(this)}
+      />
+    </div>);
+  }
+}
+
+
+ReactDOM.render(<div>
+  <Wrapper />
+</div>, document.getElementById('__react-content'));

--- a/examples/connections.js
+++ b/examples/connections.js
@@ -62,7 +62,7 @@ class Wrapper extends Component {
       connections: after,
     });
   }
-  handleActiveNodeChange(data) {
+  handleActiveNodesChange(data) {
     console.log('onActiveNode change', data);
   }
   render() {
@@ -71,7 +71,7 @@ class Wrapper extends Component {
       <SimpleApp
         connections={this.state.connections}
         onConnectionsChange={this.handleConnectionsChange.bind(this)}
-        onActiveNodeChange={this.handleActiveNodeChange.bind(this)}
+        onActiveNodesChange={this.handleActiveNodesChange.bind(this)}
       />
     </div>);
   }

--- a/src/components/Node/Node.tsx
+++ b/src/components/Node/Node.tsx
@@ -65,6 +65,7 @@ class Node extends React.Component<NodeProps, any> {
       type: UPDATE_ACTIVE_NODE,
       data,
     });
+    this.props.onActive(data);
   }
 
   connectNode(source, target) {
@@ -138,6 +139,7 @@ class Node extends React.Component<NodeProps, any> {
       type: UPDATE_ACTIVE_NODE,
       data,
     });
+    this.props.onActive(data);
   }
   mouseDown = (ev) => {
     const data = this.getCurrentNode();

--- a/src/components/Node/Node.tsx
+++ b/src/components/Node/Node.tsx
@@ -68,13 +68,8 @@ class Node extends React.Component<NodeProps, any> {
   }
 
   connectNode(source, target) {
-    console.log('>> connectNode', source, target);
     const { dispatch } = this.props;
-    dispatch({
-      type: ADD_CONNECTION,
-      source,
-      target,
-    });
+    this.props.onConnect(source, target);
     dispatch({
       type: CLEAR_TARGET_NODE,
     });

--- a/src/containers/CanvasContainer.tsx
+++ b/src/containers/CanvasContainer.tsx
@@ -10,6 +10,7 @@ import TempLink from '../components/Link/TempLink';
 import Link from '../components/Link/Link';
 
 import { REGISTER_CANVAS_CONTAINER } from '../actions';
+import { Node } from '../functions';
 
 export interface CanvasProps {
   connections: Array<any>;
@@ -36,14 +37,14 @@ class CanvasContainer extends React.Component<CanvasProps, any> {
       width: node.width,
       height: node.height,
     }, {
-      activeControllerId: data.activeControllerId,
+      activeControllerId: Node.pointMap[data.point],
     });
   }
   renderLink = (connections) => {
     return connections
       .map( connect => ({
-        source: this.getNodeData(connect.source),
-        target: this.getNodeData(connect.target),
+        source: this.getNodeData(connect.from),
+        target: this.getNodeData(connect.to),
       }))
       .filter( connect =>  connect.source && connect.target )
       .map( (data, index) => <Link data={data} key={`link-${index}`} /> );
@@ -71,6 +72,5 @@ export default connect(props => ({
   configs: props.configs,
   activeNode: props.activeNode,
   targetNode: props.targetNode,
-  connections: props.connections,
   eventProxy: props.eventProxy,
 }))(CanvasContainer);

--- a/src/functions/Connection.ts
+++ b/src/functions/Connection.ts
@@ -1,0 +1,24 @@
+export default class Connection {
+  static connectionExisted(connections, connection) {
+    return connections.find(item => item.from.id === connection.from.id && item.to.id === connection.to.id);
+  }
+  private from;
+  private to;
+
+  constructor(connect) {
+    if (Array.isArray(connect)) {
+      this.from = {
+        id: connect[0],
+      };
+      this.to = {
+        id: connect[1],
+      };
+    } else if (connect.constructor === Object) {
+      const { from, to } = connect;
+      this.from = from;
+      this.to = to;
+    } else {
+      console.error('constructor Connection failed');
+    }
+  }
+}

--- a/src/functions/Node.ts
+++ b/src/functions/Node.ts
@@ -1,0 +1,26 @@
+export default class Node {
+  public x: number;
+  public y: number;
+  public id: number;
+  public activeControllerId: number;
+  public width: number;
+  public height: number;
+  static pointMap = {
+    't': 1,
+    'l': 3,
+    'r': 4,
+    'b': 6,
+  }
+  static valueMap = {
+    '1': 't',
+    '3': 'l',
+    '4': 'r',
+    '6': 'b',
+  }
+  constructor(data) {
+    Object.assign(this, data);
+    this.x = data.x || 0;
+    this.y = data.y || 0;
+    this.activeControllerId = null;
+  }
+}

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -10,6 +10,8 @@ import createConnector from './createConnector';
 import getControllerPosition from './getControllerPosition';
 
 import triggerEvent from './triggerEvent';
+import Connection from './Connection';
+import Node from './Node';
 
 export {
   parseData,
@@ -21,4 +23,6 @@ export {
   getControllerPosition,
   createConnector,
   triggerEvent,
+  Connection,
+  Node,
 }

--- a/src/providers/Container.tsx
+++ b/src/providers/Container.tsx
@@ -53,7 +53,7 @@ export default function providerFunction(configs: ProviderConfig = defaultConfig
       static childContextTypes = {
         store: React.PropTypes.any,
         onConnectionsChange: React.PropTypes.func,
-        onActiveNodeChange: React.PropTypes.func,
+        onActiveNodesChange: React.PropTypes.func,
         connections: React.PropTypes.array,
       };
 
@@ -61,7 +61,7 @@ export default function providerFunction(configs: ProviderConfig = defaultConfig
         return {
           store,
           onConnectionsChange: this.props.onConnectionsChange,
-          onActiveNodeChange: this.props.onActiveNodeChange,
+          onActiveNodesChange: this.props.onActiveNodesChange,
           connections: this.props.connections.map(c => c.constructor === Connection ? c : new Connection(c)),
         };
       }

--- a/src/providers/Container.tsx
+++ b/src/providers/Container.tsx
@@ -53,6 +53,7 @@ export default function providerFunction(configs: ProviderConfig = defaultConfig
       static childContextTypes = {
         store: React.PropTypes.any,
         onConnectionsChange: React.PropTypes.func,
+        onActiveNodeChange: React.PropTypes.func,
         connections: React.PropTypes.array,
       };
 
@@ -60,6 +61,7 @@ export default function providerFunction(configs: ProviderConfig = defaultConfig
         return {
           store,
           onConnectionsChange: this.props.onConnectionsChange,
+          onActiveNodeChange: this.props.onActiveNodeChange,
           connections: this.props.connections.map(c => c.constructor === Connection ? c : new Connection(c)),
         };
       }

--- a/src/providers/Node.tsx
+++ b/src/providers/Node.tsx
@@ -34,7 +34,7 @@ export default function nodeDecorator(_collect: CollectFunction = (any: any) => 
         store: React.PropTypes.any,
         connections: React.PropTypes.array,
         onConnectionsChange: React.PropTypes.func,
-        onActiveNodeChange: React.PropTypes.func,
+        onActiveNodesChange: React.PropTypes.func,
         offset: React.PropTypes.object,
         groupId: React.PropTypes.any,
       };
@@ -81,7 +81,9 @@ export default function nodeDecorator(_collect: CollectFunction = (any: any) => 
       }
       handleActive(node) {
         if (!this.props.onActive || !this.props.onActive(node)) {
-          this.context.onActiveNodeChange(node);
+          this.context.onActiveNodesChange([
+            node
+          ]);
         }
       }
 

--- a/src/providers/Node.tsx
+++ b/src/providers/Node.tsx
@@ -34,6 +34,7 @@ export default function nodeDecorator(_collect: CollectFunction = (any: any) => 
         store: React.PropTypes.any,
         connections: React.PropTypes.array,
         onConnectionsChange: React.PropTypes.func,
+        onActiveNodeChange: React.PropTypes.func,
         offset: React.PropTypes.object,
         groupId: React.PropTypes.any,
       };
@@ -57,7 +58,7 @@ export default function nodeDecorator(_collect: CollectFunction = (any: any) => 
       }
 
       handleConnect(source, target) {
-        if (!this.props.onConnect(source, target)) {
+        if (!this.props.onConnect || !this.props.onConnect(source, target)) {
           const { connections, onConnectionsChange } = this.context;
           // ! update problems
           const connection = new Connection({
@@ -78,6 +79,11 @@ export default function nodeDecorator(_collect: CollectFunction = (any: any) => 
           }
         }
       }
+      handleActive(node) {
+        if (!this.props.onActive || !this.props.onActive(node)) {
+          this.context.onActiveNodeChange(node);
+        }
+      }
 
       render() {
         const { offset } = this.context;
@@ -85,6 +91,7 @@ export default function nodeDecorator(_collect: CollectFunction = (any: any) => 
           {...this.props}
           {...this.state}
           onConnect={this.handleConnect.bind(this)}
+          onActive={this.handleActive.bind(this)}
           style={offset ? {transform: `translate3d(${-offset.x}px, ${-offset.y}px, 0)`} : {}}
         >
           <DecoratedComponent

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -97,23 +97,6 @@ function eventListeners(state = {}, actions) {
   }
 }
 
-function connections(state = [], actions) {
-    switch (actions.type) {
-      case ADD_CONNECTION:
-        // 如果 A 和 B 之间已存在连线, 则不做任何处理
-        if (state.find( item => item.source.id === actions.source.id) && state.find( item => item.target.id === actions.target.id) ) {
-          return state;
-        }
-        state.push({
-          source: actions.source,
-          target: actions.target
-        });
-        return state.slice();
-      default:
-        return state;
-    }
-}
-
 function eventProxy(state = {domContainer : null, canvasContainer: null}, actions) {
   switch (actions.type) {
     case REGISTER_CANVAS_CONTAINER:
@@ -126,7 +109,6 @@ function eventProxy(state = {domContainer : null, canvasContainer: null}, action
 export default combineReducers({
   nodes,
   groups,
-  connections,
   configs,
   activeNode,
   targetNode,


### PR DESCRIPTION
```
const Node = createNode()(<div />)
const Father = createContainer()(<div>
  <Node onConnect={(sourceNode, targetNode) => {}} onActive={(node) => {}} />
</div>);

render() {
  return (<Father
    connections={[]}
    onConnectionsChange={(before, after) =>{}}
    onActiveNodesChange={(nodes) => {}}
  />);
}
```
- connect 和 active 的时候会先触发 Node 的 onXXX，如果 onXXX 有返回值，那么就不会冒泡到 Father 的 onXXXsChange 上

demo 目前只修改了 connection.js，看下这个思路如何 @RaoHai 
